### PR TITLE
chore: Upgrade to hapi v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "data-queue": "0.0.3",
     "debug": "^3.1.0",
     "epimetheus": "^1.0.55",
-    "hapi": "^16.6.2",
-    "inert": "^4.2.1",
+    "hapi": "^17.1.1",
+    "inert": "^5.0.1",
     "libp2p-crypto": "^0.10.3",
     "mafmt": "^3.0.2",
     "merge-recursive": "0.0.3",
@@ -49,7 +49,7 @@
     "test": "test"
   },
   "devDependencies": {
-    "aegir": "^12.1.3",
+    "aegir": "^12.2.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "lodash": "^4.17.4"

--- a/src/config.js
+++ b/src/config.js
@@ -10,10 +10,8 @@ module.exports = {
     port: process.env.PORT || 13579,
     host: '0.0.0.0',
     options: {
-      connections: {
-        routes: {
-          cors: true
-        }
+      routes: {
+        cors: true
       }
     }
   },

--- a/test/rendezvous.spec.js
+++ b/test/rendezvous.spec.js
@@ -35,7 +35,7 @@ describe('rendezvous', () => {
       expect(server.info.port).to.equal(13579)
       expect(server.info.protocol).to.equal('http')
       expect(server.info.address).to.equal('0.0.0.0')
-      server.stop(done)
+      server.stop().then(done, done)
     })
   })
 
@@ -49,7 +49,7 @@ describe('rendezvous', () => {
       expect(server.info.port).to.equal(12345)
       expect(server.info.protocol).to.equal('http')
       expect(server.info.address).to.equal('0.0.0.0')
-      server.stop(done)
+      server.stop().then(done, done)
     })
   })
 
@@ -191,6 +191,6 @@ describe('rendezvous', () => {
   it('stop signalling server', (done) => {
     c1.disconnect()
     c2.disconnect()
-    r.stop(done)
+    r.stop().then(done, done)
   })
 })


### PR DESCRIPTION
Hapi v17 was released quite recently

This pr updates hapi to the latest version

Blocking issues:
 - [ ] epimeteus hapi v17 support https://github.com/roylines/node-epimetheus/issues/43
 - [x] `process.env` in tests https://github.com/ipfs/aegir/issues/177

ToDos:
 - [ ] Make tests pass