### PR TITLE
Fix installed binary's name

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The rendezvous service for libp2p-websocket-star",
   "main": "src/index.js",
   "bin": {
+    "rendezvous": "src/bin.js",
     "websocket-star": "src/bin.js"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The rendezvous service for libp2p-websocket-star",
   "main": "src/index.js",
   "bin": {
-    "rendezvous": "src/bin.js"
+    "websocket-star": "src/bin.js"
   },
   "scripts": {
     "start": "node src/bin.js",


### PR DESCRIPTION
Currently, the [documentation](https://github.com/libp2p/js-libp2p-websocket-star-rendezvous#usage) says to start the server, we run: 
`websockets-star --port=9090 --host=127.0.0.1`. 

However, the binary that the package.json installs is  `rendezvous`.

This PR will change the name of the binary that gets installed when installed with `npm --global  libp2p-websocket-star-rendezvous` to `websockets-star`.

Another way to fix this would be to update the [README](https://github.com/libp2p/js-libp2p-websocket-star-rendezvous#usage) `rendezvous --port=9090 --host=127.0.0.1`. Let me know if you feel changing the docs is more appropriate to fix this and I can open a PR for that (and close this).