### PR TITLE
Fix dokku deploys + correct multiaddr on website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ COPY . /app
 WORKDIR /app
 RUN npm i --production
 ENTRYPOINT ["/usr/local/bin/dumb-init", "node", "src/bin.js"]
-EXPOSE 9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:8
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && chmod +x /usr/local/bin/dumb-init
-COPY . /app
-WORKDIR /app
+WORKDIR /usr/src/app
+COPY package.json .
 RUN npm i --production
+COPY . .
 ENTRYPOINT ["/usr/local/bin/dumb-init", "node", "src/bin.js"]

--- a/src/index.html
+++ b/src/index.html
@@ -43,14 +43,12 @@
     addr += '/ip4/' + f.h + '/tcp/' + f.port + '/'
   } else if (f.port && ipv6Regex.test(f.h)) {
     addr += '/ip6/' + f.h + '/tcp/' + f.port + '/'
-  } else if (f.port) {
-    addr += '/dns/' + f.h + '/tcp/' + f.port + '/'
   } else if (ipv4Regex.test(f.h)) {
     addr += '/ip4/' + f.h + '/tcp/' + f.protoport + '/'
   } else if (ipv6Regex.test(f.h)) {
     addr += '/ip6/' + f.h + '/tcp/' + f.protoport + '/'
   } else {
-    addr += '/dns/' + f.h + '/'
+    addr += '/dns4/' + f.h + '/tcp/' + f.protoport + '/'
   }
   if (f.protocol == 'https:') addr += 'wss/'
   else addr += 'ws/'


### PR DESCRIPTION
- Cache docker layers if possible
- Remove EXPOSE of ports, letting the runtime decide port instead
- Show correct multiaddr on website (dns vs dns4)