### PR TITLE
fix: Logo was broken on main page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
 <body>
   <center>
     <br>
-    <img src="https://github.com/libp2p/libp2p/raw/master/logo/alternates/libp2p-logo-alt-4.png" alt="Libp2p Logo" width="128" />
+    <img src="https://raw.githubusercontent.com/libp2p/libp2p/master/logo/white-bg-1.png" alt="Libp2p Logo" width="128" />
     <h2>This is a libp2p-websocket-star signalling-server</h2>
     <p>Signaling Servers are used in libp2p to allow browsers and clients with restricted port-forwarding<br>to communicate with other peers in the libp2p network</p>
     <div id="addr"></div>


### PR DESCRIPTION
Before:
![screenshot](https://user-images.githubusercontent.com/7735145/47366344-ccfc3f80-d6dd-11e8-8886-0bb5d945172d.png)
