### PR TITLE
Remove warning for too many listeners on socket.io sockets

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -60,6 +60,7 @@ module.exports = (config, http) => {
   function handle (socket) {
     socket.addrs = []
     socket.cleanaddrs = {}
+    socket.setMaxListeners(0)
     sp(socket, {
       codec: 'buffer'
     })


### PR DESCRIPTION
It's fairly normal to have more than 10 listeners on a socket for the
rendezvous server.

This small change makes the test cases for peer-star-app much less chatty.