### PR TITLE
Dont use 'this' in root anon function

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "The rendezvous service for libp2p-websocket-star",
   "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "main": "src/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "bin": {
     "rendezvous": "src/bin.js",
     "websocket-star": "src/bin.js"

--- a/package.json
+++ b/package.json
@@ -28,29 +28,29 @@
   "dependencies": {
     "async": "^2.6.1",
     "data-queue": "0.0.3",
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "epimetheus": "^1.0.92",
     "hapi": "^16.6.2",
     "inert": "^4.2.1",
-    "libp2p-crypto": "~0.14.0",
+    "libp2p-crypto": "~0.14.1",
     "mafmt": "^6.0.2",
     "merge-recursive": "0.0.3",
     "minimist": "^1.2.0",
-    "multiaddr": "^5.0.0",
+    "multiaddr": "^5.0.2",
     "once": "^1.4.0",
-    "peer-id": "~0.11.0",
+    "peer-id": "~0.12.0",
     "peer-info": "~0.14.1",
     "prom-client": "^11.1.3",
     "socket.io": "^2.1.1",
     "socket.io-client": "^2.1.1",
     "socket.io-pull-stream": "~0.1.5",
-    "uuid": "^3.2.1"
+    "uuid": "^3.3.2"
   },
   "directories": {
     "test": "test"
   },
   "devDependencies": {
-    "aegir": "^15.3.1",
+    "aegir": "^17.1.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "lodash": "^4.17.11"

--- a/src/routes.js
+++ b/src/routes.js
@@ -31,7 +31,7 @@ module.exports = (config, http) => {
 
   log('create new server', config)
 
-  this._peers = {}
+  const _peers = {}
   const nonces = {}
 
   const peersMetric = config.metrics ? new client.Gauge({ name: 'rendezvous_peers', help: 'peers online now' }) : fake.gauge
@@ -42,13 +42,10 @@ module.exports = (config, http) => {
   const joinsFailureTotal = config.metrics ? new client.Counter({ name: 'rendezvous_joins_total_failure', help: 'failed joins since server started' }) : fake.counter
   const joinsTotal = config.metrics ? new client.Counter({ name: 'rendezvous_joins_total', help: 'all joins since server started' }) : fake.counter
 
-  const getPeers = () => this._peers // it's a function because, and I'm not kidding, the value of that var is different for every peer that has joined
-  const refreshMetrics = () => peersMetric.set(Object.keys(getPeers()).length)
-
-  this.peers = () => getPeers()
+  const refreshMetrics = () => peersMetric.set(Object.keys(_peers).length)
 
   function safeEmit (addr, event, arg) {
-    const peer = getPeers()[addr]
+    const peer = _peers[addr]
     if (!peer) {
       log('trying to emit %s but peer is gone', event)
       return
@@ -130,7 +127,7 @@ module.exports = (config, http) => {
 
   function joinFinalize (socket, multiaddr, cb) {
     const log = getConfig().log.bind(getConfig().log, '[' + socket.id + ']')
-    getPeers()[multiaddr] = socket
+    _peers[multiaddr] = socket
     if (!socket.stopSendingPeersIntv) socket.stopSendingPeersIntv = {}
     joinsSuccessTotal.inc()
     refreshMetrics()
@@ -146,7 +143,7 @@ module.exports = (config, http) => {
     sendPeers()
 
     function sendPeers () {
-      const list = Object.keys(getPeers())
+      const list = Object.keys(_peers)
       log(multiaddr, 'sending', (list.length - 1).toString(), 'peer(s)')
       list.forEach((mh) => {
         if (mh === multiaddr) {
@@ -167,14 +164,14 @@ module.exports = (config, http) => {
 
     socket.stopSendingPeersIntv[multiaddr] = stopSendingPeers
 
-    const otherPeers = Object.keys(getPeers()).filter(mh => mh !== multiaddr)
+    const otherPeers = Object.keys(_peers).filter(mh => mh !== multiaddr)
     cb(null, null, otherPeers)
   }
 
   function leave (socket, multiaddr) {
-    if (getPeers()[multiaddr] && getPeers()[multiaddr].id === socket.id) {
+    if (_peers[multiaddr] && _peers[multiaddr].id === socket.id) {
       socket.log('leaving', multiaddr)
-      delete getPeers()[multiaddr]
+      delete _peers[multiaddr]
       socket.addrs = socket.addrs.filter(m => m !== multiaddr)
       if (socket.stopSendingPeersIntv[multiaddr]) {
         socket.stopSendingPeersIntv[multiaddr]()
@@ -186,8 +183,8 @@ module.exports = (config, http) => {
 
   function disconnect (socket) {
     socket.log('disconnected')
-    Object.keys(getPeers()).forEach((mh) => {
-      if (getPeers()[mh].id === socket.id) {
+    Object.keys(_peers).forEach((mh) => {
+      if (_peers[mh].id === socket.id) {
         leave(socket, mh)
       }
     })
@@ -205,7 +202,7 @@ module.exports = (config, http) => {
     }
 
     log(from, 'is dialing', to)
-    const peer = getPeers()[to]
+    const peer = _peers[to]
 
     if (!peer) {
       dialsFailureTotal.inc()
@@ -226,5 +223,7 @@ module.exports = (config, http) => {
     })
   }
 
-  return this
+  return {
+    peers: () => _peers
+  }
 }


### PR DESCRIPTION
The routes.js file exports an arrow function, but `this` is being used inside the function. This PR removes the usage of `this` to avoid unwanted side effects.

**Additionally**
* Update dependencies
* And add `files` to package.json for npm whitelisting