### PR TITLE
fix: crypto challenge stall due to callback usage of async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,19 +41,19 @@
     "minimist": "^1.2.0",
     "multiaddr": "^6.1.0",
     "once": "^1.4.0",
-    "peer-id": "~0.13.1",
+    "peer-id": "~0.13.2",
     "peer-info": "~0.16.0",
     "prom-client": "^11.5.3",
-    "socket.io": "^2.0.4",
-    "socket.io-client": "^2.0.4",
-    "socket.io-pull-stream": "^0.1.1",
+    "socket.io": "^2.2.0",
+    "socket.io-client": "^2.2.0",
+    "socket.io-pull-stream": "^0.1.5",
     "uuid": "^3.1.0"
   },
   "directories": {
     "test": "test"
   },
   "devDependencies": {
-    "aegir": "^19.0.5",
+    "aegir": "^20.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "lodash": "^4.17.11"

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,7 +81,7 @@ function Protocol (log) {
   }
   this.handleSocket = (socket) => {
     socket.r = {}
-    for (let request in this.requests) {
+    for (const request in this.requests) {
       if (Object.prototype.hasOwnProperty.call(this.requests, request)) {
         const r = this.requests[request]
         socket.on(request, function () {
@@ -100,15 +100,13 @@ function Protocol (log) {
   }
 }
 
-function getIdAndValidate (pub, id, cb) {
-  Id.createFromPubKey(Buffer.from(pub, 'hex'))
-    .then(_id => {
-      if (_id.toB58String() !== id) {
-        throw Error('Id is not matching')
-      }
+async function getIdAndValidate (pub, id) {
+  const _id = await Id.createFromPubKey(Buffer.from(pub, 'hex'))
+  if (_id.toB58String() !== id) {
+    throw Error('Id is not matching')
+  }
 
-      return crypto.keys.unmarshalPublicKey(Buffer.from(pub, 'hex'))
-    }, cb)
+  return crypto.keys.unmarshalPublicKey(Buffer.from(pub, 'hex'))
 }
 
 exports = module.exports

--- a/test/rendezvous.spec.js
+++ b/test/rendezvous.spec.js
@@ -50,10 +50,10 @@ describe('signalling server client', () => {
   let c3
   let c4
 
-  let c1mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1')
-  let c2mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo2')
-  let c3mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo3')
-  let c4mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4')
+  const c1mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo1')
+  const c2mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo2')
+  const c3mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo3')
+  const c4mh = multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4')
 
   before(async () => {
     const options = {


### PR DESCRIPTION
The async/await update (https://github.com/libp2p/js-libp2p-websocket-star-rendezvous/pull/35) did not fully migrate away from callbacks. It was still using callbacks for some of the crypto library usage. This caused crypto challenge to fail.

**Note on testing**: I didn't add a new test for this as we are planning to migrate the rendezvous server into https://github.com/libp2p/js-libp2p-websocket-star, per https://github.com/libp2p/js-libp2p-websocket-star/issues/73, and the websocket-star test suite does catch this issue. I've created a [PR there](https://github.com/libp2p/js-libp2p-websocket-star/pull/75) to demonstrate the fix.

fixes: #36 